### PR TITLE
Remove spurious entry from IMM

### DIFF
--- a/imm.yaml
+++ b/imm.yaml
@@ -64,7 +64,6 @@
         -
             Score: 3
             Description: '< 1 month'
-        -
 -
     Name: 'Framework Version'
     Id: 6c0402b3-f0e3-4bd7-83fe-04bb6dca7924


### PR DESCRIPTION
A straggling extra line with a single `-` was causing errors in the IMM badge code