### PR TITLE
IMM review

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,4 @@ The IMM is endjin's IP quality framework.
 
 [![Production Use](https://endimmfuncdev.azurewebsites.net/api/imm/github/ais-dotnet/Ais.Net/rule/87ee2c3e-b17a-4939-b969-2c9c034d05d7?cache=false)](https://endimmfuncdev.azurewebsites.net/api/imm/github/ais-dotnet/Ais.Net/rule/87ee2c3e-b17a-4939-b969-2c9c034d05d7?cache=false)
 
-[![Insights](https://endimmfuncdev.azurewebsites.net/api/imm/github/ais-dotnet/Ais.Net/rule/71a02488-2dc9-4d25-94fa-8c2346169f8b?cache=false)](https://endimmfuncdev.azurewebsites.net/api/imm/github/ais-dotnet/Ais.Net/rule/71a02488-2dc9-4d25-94fa-8c2346169f8b?cache=false)
-
 [![Packaging](https://endimmfuncdev.azurewebsites.net/api/imm/github/ais-dotnet/Ais.Net/rule/547fd9f5-9caf-449f-82d9-4fba9e7ce13a?cache=false)](https://endimmfuncdev.azurewebsites.net/api/imm/github/ais-dotnet/Ais.Net/rule/547fd9f5-9caf-449f-82d9-4fba9e7ce13a?cache=false)
-
-[![Deployment](https://endimmfuncdev.azurewebsites.net/api/imm/github/ais-dotnet/Ais.Net/rule/edea4593-d2dd-485b-bc1b-aaaf18f098f9?cache=false)](https://endimmfuncdev.azurewebsites.net/api/imm/github/ais-dotnet/Ais.Net/rule/edea4593-d2dd-485b-bc1b-aaaf18f098f9?cache=false)

--- a/imm.yaml
+++ b/imm.yaml
@@ -62,7 +62,7 @@
     Id: da4ed776-0365-4d8a-a297-c4e91a14d646
     Measures:
         -
-            Date: 2020-01-21
+            Date: 2021-02-03
 -
     Name: 'Framework Version'
     Id: 6c0402b3-f0e3-4bd7-83fe-04bb6dca7924
@@ -106,10 +106,7 @@
 -
     Name: Insights
     Id: 71a02488-2dc9-4d25-94fa-8c2346169f8b
-    Measures:
-        -
-            Score: 0
-            Description: None
+    OptOut: true
 -
     Name: Packaging
     Id: 547fd9f5-9caf-449f-82d9-4fba9e7ce13a
@@ -126,7 +123,4 @@
 -
     Name: Deployment
     Id: edea4593-d2dd-485b-bc1b-aaaf18f098f9
-    Measures:
-        -
-            Score: 0
-            Description: None
+    OptOut: true


### PR DESCRIPTION
Since the last review, Insights and Deployment have been made optional,
and we opt out of each now.

The highly performance-sensitive nature of
this library means that adding telemetry would incur unacceptable
overheads; applications using this library would typically collect any
performance telemetry at a higher level. And this is a leaf component
that is never deployed in isolation, and which has no deployment requirements of
its own, so there is nothing to do on that front.

In this review, we therefore now opt out of both rules.