### PR TITLE
Replace SpecFlow with Reqnroll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,7 +339,7 @@ coverage.cobertura.xml
 # VS Code config files
 /.vscode
 
-# Generated SpecFlow files
+# Generated Reqnroll files
 *.feature.cs
 
 # SBOMs

--- a/Solutions/Ais.Net.Specs/Ais.Net.Specs.csproj
+++ b/Solutions/Ais.Net.Specs/Ais.Net.Specs.csproj
@@ -8,76 +8,15 @@
 
   <PropertyGroup>
 	<IsPackable>false</IsPackable>
-    <!--
-    Note: SA1633 and SA1649 are disabled because of a bug introduced by SpecFlow 3.1.
-    If https://github.com/SpecFlowOSS/SpecFlow/pull/1790 is ever successfully merged, we should re-enable them.
-    -->
-    <NoWarn>RCS1029;RCS1089;SA1600;CS1591;SA1633;SA1649</NoWarn>
+    <NoWarn>RCS1029;RCS1089;SA1600;CS1591</NoWarn>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="1.6.0" />
+    <PackageReference Include="Corvus.Testing.ReqnRoll.NUnit" Version="4.0.5" />
   </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\Ais.Net\Ais.Net.csproj" />
   </ItemGroup>
-  <ItemGroup>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Update="Ais\Net\Specs\AisMessageTypes\LongRangeAisBroadcastParserSpecs.feature.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>LongRangeAisBroadcastParserSpecs.feature</DependentUpon>
-    </Compile>
-    <Compile Update="Ais\Net\Specs\AisMessageTypes\PositionReportClassAParserSpecs.feature.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>PositionReportClassAParserSpecs.feature</DependentUpon>
-    </Compile>
-    <Compile Update="Ais\Net\Specs\AisMessageTypes\PositionReportClassBParserSpecs.feature.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>PositionReportClassBParserSpecs.feature</DependentUpon>
-    </Compile>
-    <Compile Update="Ais\Net\Specs\AisStringsSpecs.feature.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>AisStringsSpecs.feature</DependentUpon>
-    </Compile>
-    <Compile Update="Ais\Net\Specs\AisMessageTypes\PositionReportExtendedClassBParserSpecs.feature.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>PositionReportExtendedClassBParserSpecs.feature</DependentUpon>
-    </Compile>
-    <Compile Update="Ais\Net\Specs\AisMessageTypes\StaticAndVoyageRelatedDataParserSpecs.feature.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>StaticAndVoyageRelatedDataParserSpecs.feature</DependentUpon>
-    </Compile>
-    <Compile Update="Ais\Net\Specs\AisMessageTypes\StaticDataReportParserSpecs.feature.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>StaticDataReportParserSpecs.feature</DependentUpon>
-    </Compile>
-    <Compile Update="Ais\Net\Specs\NmeaAisBitVectorParserSpecs.feature.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>NmeaAisBitVectorParserSpecs.feature</DependentUpon>
-    </Compile>
-    <Compile Update="Ais\Net\Specs\NmeaLineToAisStreamAdapterSpecs.feature.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>NmeaLineToAisStreamAdapterSpecs.feature</DependentUpon>
-    </Compile>
-    <Compile Update="Ais\Net\Specs\NmeaStreamParserByLineSpecs.feature.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>NmeaStreamParserByLineSpecs.feature</DependentUpon>
-    </Compile>
-    <Compile Update="Ais\Net\Specs\NmeaStreamParserByMessageSpecs.feature.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>NmeaStreamParserByMessageSpecs.feature</DependentUpon>
-    </Compile>
-  </ItemGroup>
+
 </Project>

--- a/Solutions/Ais.Net.Specs/Ais/Net/Specs/AisMessageTypes/LongRangeAisBroadcastParserSpecsSteps.cs
+++ b/Solutions/Ais.Net.Specs/Ais/Net/Specs/AisMessageTypes/LongRangeAisBroadcastParserSpecsSteps.cs
@@ -6,7 +6,7 @@ namespace Ais.Net.Specs.AisMessageTypes
 {
     using System.Text;
     using NUnit.Framework;
-    using TechTalk.SpecFlow;
+    using Reqnroll;
 
     [Binding]
     public class LongRangeAisBroadcastParserSpecsSteps

--- a/Solutions/Ais.Net.Specs/Ais/Net/Specs/AisMessageTypes/PositionReportClassAParserSpecsSteps.cs
+++ b/Solutions/Ais.Net.Specs/Ais/Net/Specs/AisMessageTypes/PositionReportClassAParserSpecsSteps.cs
@@ -6,7 +6,7 @@ namespace Ais.Net.Specs.AisMessageTypes
 {
     using System.Text;
     using NUnit.Framework;
-    using TechTalk.SpecFlow;
+    using Reqnroll;
 
     [Binding]
     public class PositionReportClassAParserSpecsSteps

--- a/Solutions/Ais.Net.Specs/Ais/Net/Specs/AisMessageTypes/PositionReportClassBParserSpecsSteps.cs
+++ b/Solutions/Ais.Net.Specs/Ais/Net/Specs/AisMessageTypes/PositionReportClassBParserSpecsSteps.cs
@@ -7,7 +7,7 @@ namespace Ais.Net.Specs.AisMessageTypes
     using System.Text;
     using Ais.Net;
     using NUnit.Framework;
-    using TechTalk.SpecFlow;
+    using Reqnroll;
 
     [Binding]
     public class PositionReportClassBParserSpecsSteps

--- a/Solutions/Ais.Net.Specs/Ais/Net/Specs/AisMessageTypes/PositionReportExtendedClassBParserSpecsSteps.cs
+++ b/Solutions/Ais.Net.Specs/Ais/Net/Specs/AisMessageTypes/PositionReportExtendedClassBParserSpecsSteps.cs
@@ -6,7 +6,7 @@ namespace Ais.Net.Specs.AisMessageTypes
 {
     using System.Text;
     using NUnit.Framework;
-    using TechTalk.SpecFlow;
+    using Reqnroll;
 
     [Binding]
     public class PositionReportExtendedClassBParserSpecsSteps

--- a/Solutions/Ais.Net.Specs/Ais/Net/Specs/AisMessageTypes/StaticAndVoyageRelatedDataParserSpecsSteps.cs
+++ b/Solutions/Ais.Net.Specs/Ais/Net/Specs/AisMessageTypes/StaticAndVoyageRelatedDataParserSpecsSteps.cs
@@ -6,7 +6,7 @@ namespace Ais.Net.Specs.AisMessageTypes
 {
     using System.Text;
     using NUnit.Framework;
-    using TechTalk.SpecFlow;
+    using Reqnroll;
 
     [Binding]
     public class StaticAndVoyageRelatedDataParserSpecsSteps

--- a/Solutions/Ais.Net.Specs/Ais/Net/Specs/AisMessageTypes/StaticDataReportParserSpecsSteps.cs
+++ b/Solutions/Ais.Net.Specs/Ais/Net/Specs/AisMessageTypes/StaticDataReportParserSpecsSteps.cs
@@ -7,7 +7,7 @@ namespace Ais.Net.Specs.AisMessageTypes
     using System;
     using System.Text;
     using NUnit.Framework;
-    using TechTalk.SpecFlow;
+    using Reqnroll;
 
     [Binding]
     public class StaticDataReportParserSpecsSteps

--- a/Solutions/Ais.Net.Specs/Ais/Net/Specs/AisStringsSpecsSteps.cs
+++ b/Solutions/Ais.Net.Specs/Ais/Net/Specs/AisStringsSpecsSteps.cs
@@ -6,7 +6,7 @@ namespace Ais.Net.Specs
 {
     using Ais.Net;
     using NUnit.Framework;
-    using TechTalk.SpecFlow;
+    using Reqnroll;
 
     [Binding]
     public class AisStringsSpecsSteps
@@ -16,8 +16,8 @@ namespace Ais.Net.Specs
         public static void TestString(string expected, int fieldSizeInChars, in NmeaAisTextFieldParser parser)
         {
             // Although text fields are supposed to be padded with '@' characters, it's common
-            // for real transponders to be set up to use spaces instead. And since SpecFlow
-            // doesn't make is straightforward to include a space at the start or end of a test
+            // for real transponders to be set up to use spaces instead. And since Reqnroll
+            // doesn't make it straightforward to include a space at the start or end of a test
             // string, we should pad out with spaces by default, because tests can explicitly
             // pad with @ in cases where that's what's expected.
             expected = expected.PadRight(fieldSizeInChars, ' ');

--- a/Solutions/Ais.Net.Specs/Ais/Net/Specs/NmeaAisBitVectorParserSpecsSteps.cs
+++ b/Solutions/Ais.Net.Specs/Ais/Net/Specs/NmeaAisBitVectorParserSpecsSteps.cs
@@ -6,7 +6,7 @@ namespace Ais.Net.Specs
 {
     using System.Text;
     using NUnit.Framework;
-    using TechTalk.SpecFlow;
+    using Reqnroll;
 
     [Binding]
     public class NmeaAisBitVectorParserSpecsSteps

--- a/Solutions/Ais.Net.Specs/Ais/Net/Specs/NmeaAisMessageStreamProcessorBindings.cs
+++ b/Solutions/Ais.Net.Specs/Ais/Net/Specs/NmeaAisMessageStreamProcessorBindings.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NmeaLineToAisStreamAdapterSpecsSteps.cs" company="Endjin Limited">
+﻿// <copyright file="NmeaAisMessageStreamProcessorBindings.cs" company="Endjin Limited">
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
@@ -9,7 +9,7 @@ namespace Ais.Net.Specs
     using System.Collections.Generic;
     using System.Text;
     using NUnit.Framework;
-    using TechTalk.SpecFlow;
+    using Reqnroll;
 
     [Binding]
     public class NmeaAisMessageStreamProcessorBindings

--- a/Solutions/Ais.Net.Specs/Ais/Net/Specs/NmeaLineToAisStreamAdapterSpecsSteps.cs
+++ b/Solutions/Ais.Net.Specs/Ais/Net/Specs/NmeaLineToAisStreamAdapterSpecsSteps.cs
@@ -7,7 +7,7 @@ namespace Ais.Net.Specs
     using System;
     using System.Text;
     using NUnit.Framework;
-    using TechTalk.SpecFlow;
+    using Reqnroll;
 
     [Binding]
     public class NmeaLineToAisStreamAdapterSpecsSteps : IDisposable

--- a/Solutions/Ais.Net.Specs/Ais/Net/Specs/NmeaStreamParserSpecsSteps.cs
+++ b/Solutions/Ais.Net.Specs/Ais/Net/Specs/NmeaStreamParserSpecsSteps.cs
@@ -10,7 +10,7 @@ namespace Ais.Net.Specs
     using System.Text;
     using System.Threading.Tasks;
     using NUnit.Framework;
-    using TechTalk.SpecFlow;
+    using Reqnroll;
 
     [Binding]
     public class NmeaStreamParserSpecsSteps

--- a/Solutions/Ais.Net.Specs/Ais/Net/Specs/ParsePayloadSpecsSteps.cs
+++ b/Solutions/Ais.Net.Specs/Ais/Net/Specs/ParsePayloadSpecsSteps.cs
@@ -6,7 +6,7 @@ namespace Ais.Net.Specs
 {
     using System.Text;
     using NUnit.Framework;
-    using TechTalk.SpecFlow;
+    using Reqnroll;
 
     [Binding]
     public class ParsePayloadSpecsSteps

--- a/Solutions/Ais.Net.Specs/Ais/Net/Specs/SentenceLayerSpecsSteps.cs
+++ b/Solutions/Ais.Net.Specs/Ais/Net/Specs/SentenceLayerSpecsSteps.cs
@@ -6,7 +6,7 @@ namespace Ais.Net.Specs
 {
     using System.Text;
     using NUnit.Framework;
-    using TechTalk.SpecFlow;
+    using Reqnroll;
 
     [Binding]
     public class SentenceLayerSpecsSteps


### PR DESCRIPTION
Resolves #188

SpecFlow is effectively defunct. But Reqnroll is effectively the same project by another name, so we've moved over to it.